### PR TITLE
Remove redundant logic annotations

### DIFF
--- a/worlds/witness/WitnessLogic.txt
+++ b/worlds/witness/WitnessLogic.txt
@@ -10,7 +10,7 @@ Tutorial (Tutorial) - Outside Tutorial - 0x03629:
 158006 - 0x0A3B2 (Back Right) - True - True
 158007 - 0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
 158008 - 0x03505 (Gate Close) - 0x2FAF6 - True
-158009 - 0x0C335 (Pillar) - True - Triangles - True
+158009 - 0x0C335 (Pillar) - True - Triangles
 158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
 
 Outside Tutorial (Outside Tutorial) - Outside Tutorial Path To Outpost - 0x03BA2:
@@ -104,7 +104,7 @@ Symmetry Island Upper (Symmetry Island):
 158069 - 0x00A64 (Blue 2) - 0x00A61 & 0x00A52 - Symmetry & Colored Dots
 158070 - 0x00A68 (Blue 3) - 0x00A64 & 0x00A57 - Symmetry & Colored Dots
 158700 - 0x0360D (Laser Panel) - 0x00A68 - True
-Laser - 0x00509 (Laser) - 0x0360D - True
+Laser - 0x00509 (Laser) - 0x0360D
 
 Orchard (Orchard) - Main Island - True - Orchard Beyond First Gate - 0x03307:
 158071 - 0x00143 (Apple Tree 1) - True - True
@@ -134,7 +134,7 @@ Desert Outside (Desert) - Main Island - True - Desert Floodlight Room - 0x09FEE:
 158084 - 0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
 158085 - 0x09F86 (Surface 8 Control) - 0x0A053 - True
 158086 - 0x0C339 (Light Room Entry Panel) - 0x09F94 - True
-Door - 0x09FEE (Light Room Entry) - 0x0C339 - True
+Door - 0x09FEE (Light Room Entry) - 0x0C339
 158701 - 0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
 Laser - 0x012FB (Laser) - 0x03608
 

--- a/worlds/witness/WitnessLogicExpert.txt
+++ b/worlds/witness/WitnessLogicExpert.txt
@@ -10,7 +10,7 @@ Tutorial (Tutorial) - Outside Tutorial - True:
 158006 - 0x0A3B2 (Back Right) - True - Dots & Full Dots
 158007 - 0x03629 (Gate Open) - 0x002C2 - Symmetry & Dots
 158008 - 0x03505 (Gate Close) - 0x2FAF6 - False
-158009 - 0x0C335 (Pillar) - True - Triangles - True
+158009 - 0x0C335 (Pillar) - True - Triangles
 158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
 
 Outside Tutorial (Outside Tutorial) - Outside Tutorial Path To Outpost - 0x03BA2:
@@ -104,7 +104,7 @@ Symmetry Island Upper (Symmetry Island):
 158069 - 0x00A64 (Blue 2) - 0x00A61 & 0x00A52 - Symmetry & Colored Dots
 158070 - 0x00A68 (Blue 3) - 0x00A64 & 0x00A57 - Symmetry & Colored Dots
 158700 - 0x0360D (Laser Panel) - 0x00A68 - True
-Laser - 0x00509 (Laser) - 0x0360D - True
+Laser - 0x00509 (Laser) - 0x0360D
 
 Orchard (Orchard) - Main Island - True - Orchard Beyond First Gate - 0x03307:
 158071 - 0x00143 (Apple Tree 1) - True - Environment
@@ -134,7 +134,7 @@ Desert Outside (Desert) - Main Island - True - Desert Floodlight Room - 0x09FEE:
 158084 - 0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - Reflection
 158085 - 0x09F86 (Surface 8 Control) - 0x0A053 - True
 158086 - 0x0C339 (Light Room Entry Panel) - 0x09F94 - True
-Door - 0x09FEE (Light Room Entry) - 0x0C339 - True
+Door - 0x09FEE (Light Room Entry) - 0x0C339
 158701 - 0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
 Laser - 0x012FB (Laser) - 0x03608
 

--- a/worlds/witness/WitnessLogicExpert.txt
+++ b/worlds/witness/WitnessLogicExpert.txt
@@ -914,7 +914,7 @@ Final Room (Mountain Final Room) - Elevator - 0x339BB & 0x33961:
 158522 - 0x0383A (Right Pillar 1) - True - Stars & Eraser & Triangles & Stars + Same Colored Symbol
 158523 - 0x09E56 (Right Pillar 2) - 0x0383A - Dots & Full Dots & Triangles & Symmetry
 158524 - 0x09E5A (Right Pillar 3) - 0x09E56 - Dots & Shapers & Stars & Negative Shapers & Stars + Same Colored Symbol & Symmetry
-158525 - 0x33961 (Right Pillar 4) - 0x09E5A - Eraser & Symmetry & Stars & Stars + Same Colored Symbols & Negative Shapers & Shapers
+158525 - 0x33961 (Right Pillar 4) - 0x09E5A - Eraser & Symmetry & Stars & Stars + Same Colored Symbol & Negative Shapers & Shapers
 158526 - 0x0383D (Left Pillar 1) - True - Stars & Black/White Squares & Stars + Same Colored Symbol
 158527 - 0x0383F (Left Pillar 2) - 0x0383D - Triangles & Symmetry
 158528 - 0x03859 (Left Pillar 3) - 0x0383F - Symmetry & Shapers & Black/White Squares

--- a/worlds/witness/WitnessLogicExpert.txt
+++ b/worlds/witness/WitnessLogicExpert.txt
@@ -88,11 +88,11 @@ Symmetry Island Lower (Symmetry Island) - Symmetry Island Upper - 0x18269:
 158056 - 0x00070 (Left 5) - 0x0006F - Symmetry & Colored Dots & Triangles
 158057 - 0x00071 (Left 6) - 0x00070 - Symmetry & Triangles
 158058 - 0x00076 (Left 7) - 0x00071 - Symmetry & Triangles
-158059 - 0x009B8 (Scenery Outlines 1) - True - Symmetry & Environment
-158060 - 0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry & Environment
-158061 - 0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry & Environment
-158062 - 0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry & Environment
-158063 - 0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry & Environment
+158059 - 0x009B8 (Scenery Outlines 1) - True - Symmetry
+158060 - 0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
+158061 - 0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
+158062 - 0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
+158063 - 0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
 158064 - 0x1C349 (Upper Panel) - 0x00076 - Symmetry & Triangles
 Door - 0x18269 (Upper) - 0x1C349
 
@@ -107,14 +107,14 @@ Symmetry Island Upper (Symmetry Island):
 Laser - 0x00509 (Laser) - 0x0360D
 
 Orchard (Orchard) - Main Island - True - Orchard Beyond First Gate - 0x03307:
-158071 - 0x00143 (Apple Tree 1) - True - Environment
-158072 - 0x0003B (Apple Tree 2) - 0x00143 - Environment
-158073 - 0x00055 (Apple Tree 3) - 0x0003B - Environment
+158071 - 0x00143 (Apple Tree 1) - True - True
+158072 - 0x0003B (Apple Tree 2) - 0x00143 - True
+158073 - 0x00055 (Apple Tree 3) - 0x0003B - True
 Door - 0x03307 (First Gate) - 0x00055
 
 Orchard Beyond First Gate (Orchard) - Orchard End - 0x03313:
-158074 - 0x032F7 (Apple Tree 4) - 0x00055 - Environment
-158075 - 0x032FF (Apple Tree 5) - 0x032F7 - Environment
+158074 - 0x032F7 (Apple Tree 4) - 0x00055 - True
+158075 - 0x032FF (Apple Tree 5) - 0x032F7 - True
 Door - 0x03313 (Second Gate) - 0x032FF
 
 Orchard End (Orchard):
@@ -123,15 +123,15 @@ Desert Outside (Desert) - Main Island - True - Desert Floodlight Room - 0x09FEE:
 158652 - 0x0CC7B (Vault) - True - Dots & Full Dots & Stars & Stars + Same Colored Symbol & Eraser & Triangles & Shapers & Negative Shapers & Colored Squares
 158653 - 0x0339E (Vault Box) - 0x0CC7B - True
 158602 - 0x17CE7 (Discard) - True - Arrows
-158076 - 0x00698 (Surface 1) - True - Reflection
-158077 - 0x0048F (Surface 2) - 0x00698 - Reflection
-158078 - 0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - Reflection
+158076 - 0x00698 (Surface 1) - True - True
+158077 - 0x0048F (Surface 2) - 0x00698 - True
+158078 - 0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
 158079 - 0x09FA0 (Surface 3 Control) - 0x0048F - True
-158080 - 0x0A036 (Surface 4) - 0x09F92 - Reflection
-158081 - 0x09DA6 (Surface 5) - 0x09F92 - Reflection
-158082 - 0x0A049 (Surface 6) - 0x09F92 - Reflection
-158083 - 0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - Reflection
-158084 - 0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - Reflection
+158080 - 0x0A036 (Surface 4) - 0x09F92 - True
+158081 - 0x09DA6 (Surface 5) - 0x09F92 - True
+158082 - 0x0A049 (Surface 6) - 0x09F92 - True
+158083 - 0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
+158084 - 0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
 158085 - 0x09F86 (Surface 8 Control) - 0x0A053 - True
 158086 - 0x0C339 (Light Room Entry Panel) - 0x09F94 - True
 Door - 0x09FEE (Light Room Entry) - 0x0C339
@@ -140,18 +140,18 @@ Laser - 0x012FB (Laser) - 0x03608
 
 Desert Floodlight Room (Desert) - Desert Pond Room - 0x0C2C3:
 158087 - 0x09FAA (Light Control) - True - True
-158088 - 0x00422 (Light Room 1) - 0x09FAA - Reflection
-158089 - 0x006E3 (Light Room 2) - 0x09FAA - Reflection
-158090 - 0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - Reflection
+158088 - 0x00422 (Light Room 1) - 0x09FAA - True
+158089 - 0x006E3 (Light Room 2) - 0x09FAA - True
+158090 - 0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
 Door - 0x0C2C3 (Pond Room Entry) - 0x0A02D
 
 Desert Pond Room (Desert) - Desert Water Levels Room - 0x0A24B:
-158091 - 0x00C72 (Pond Room 1) - True - Reflection
-158092 - 0x0129D (Pond Room 2) - 0x00C72 - Reflection
-158093 - 0x008BB (Pond Room 3) - 0x0129D - Reflection
-158094 - 0x0078D (Pond Room 4) - 0x008BB - Reflection
-158095 - 0x18313 (Pond Room 5) - 0x0078D - Reflection
-158096 - 0x0A249 (Flood Room Entry Panel) - 0x18313 - Reflection
+158091 - 0x00C72 (Pond Room 1) - True - True
+158092 - 0x0129D (Pond Room 2) - 0x00C72 - True
+158093 - 0x008BB (Pond Room 3) - 0x0129D - True
+158094 - 0x0078D (Pond Room 4) - 0x008BB - True
+158095 - 0x18313 (Pond Room 5) - 0x0078D - True
+158096 - 0x0A249 (Flood Room Entry Panel) - 0x18313 - True
 Door - 0x0A24B (Flood Room Entry) - 0x0A249
 
 Desert Water Levels Room (Desert) - Desert Elevator Room - 0x0C316:
@@ -163,21 +163,21 @@ Desert Water Levels Room (Desert) - Desert Elevator Room - 0x0C316:
 158102 - 0x1831D (Raise Water Level Far Right) - True - True
 158103 - 0x1C2B1 (Raise Water Level Near Left) - True - True
 158104 - 0x1831B (Raise Water Level Near Right) - True - True
-158105 - 0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - Reflection
-158106 - 0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - Reflection
-158107 - 0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - Reflection
-158108 - 0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - Reflection
-158109 - 0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - Reflection
-158110 - 0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - Reflection
+158105 - 0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
+158106 - 0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
+158107 - 0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
+158108 - 0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
+158109 - 0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
+158110 - 0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
 Door - 0x0C316 (Elevator Room Entry) - 0x18076
 
 Desert Elevator Room (Desert) - Desert Lowest Level Inbetween Shortcuts - 0x012FB:
-158111 - 0x17C31 (Final Transparent) - True - Reflection
-158113 - 0x012D7 (Final Hexagonal) - 0x17C31 & 0x0A015 - Reflection
+158111 - 0x17C31 (Final Transparent) - True - True
+158113 - 0x012D7 (Final Hexagonal) - 0x17C31 & 0x0A015 - True
 158114 - 0x0A015 (Final Hexagonal Control) - 0x17C31 - True
-158115 - 0x0A15C (Final Bent 1) - True - Reflection
-158116 - 0x09FFF (Final Bent 2) - 0x0A15C - Reflection
-158117 - 0x0A15F (Final Bent 3) - 0x09FFF - Reflection
+158115 - 0x0A15C (Final Bent 1) - True - True
+158116 - 0x09FFF (Final Bent 2) - 0x0A15C - True
+158117 - 0x0A15F (Final Bent 3) - 0x09FFF - True
 
 Desert Lowest Level Inbetween Shortcuts (Desert):
 
@@ -271,90 +271,90 @@ Door - 0x3865F (Second Barrier) - 0x38663
 Shadows (Shadows) - Main Island - True - Shadows Ledge - 0x19B24 - Shadows Laser Room - 0x194B2 & 0x19665:
 158170 - 0x334DB (Door Timer Outside) - True - True
 Door - 0x19B24 (Timed Door) - 0x334DB
-158171 - 0x0AC74 (Intro 6) - 0x0A8DC - Shadows Avoid
-158172 - 0x0AC7A (Intro 7) - 0x0AC74 - Shadows Avoid
-158173 - 0x0A8E0 (Intro 8) - 0x0AC7A - Shadows Avoid
-158174 - 0x386FA (Far 1) - 0x0A8E0 - Shadows Avoid & Environment
-158175 - 0x1C33F (Far 2) - 0x386FA - Shadows Avoid & Environment
-158176 - 0x196E2 (Far 3) - 0x1C33F - Shadows Avoid & Environment
-158177 - 0x1972A (Far 4) - 0x196E2 - Shadows Avoid & Environment
-158178 - 0x19809 (Far 5) - 0x1972A - Shadows Avoid & Environment
-158179 - 0x19806 (Far 6) - 0x19809 - Shadows Avoid & Environment
-158180 - 0x196F8 (Far 7) - 0x19806 - Shadows Avoid & Environment
-158181 - 0x1972F (Far 8) - 0x196F8 - Shadows Avoid & Environment
+158171 - 0x0AC74 (Intro 6) - 0x0A8DC - True
+158172 - 0x0AC7A (Intro 7) - 0x0AC74 - True
+158173 - 0x0A8E0 (Intro 8) - 0x0AC7A - True
+158174 - 0x386FA (Far 1) - 0x0A8E0 - True
+158175 - 0x1C33F (Far 2) - 0x386FA - True
+158176 - 0x196E2 (Far 3) - 0x1C33F - True
+158177 - 0x1972A (Far 4) - 0x196E2 - True
+158178 - 0x19809 (Far 5) - 0x1972A - True
+158179 - 0x19806 (Far 6) - 0x19809 - True
+158180 - 0x196F8 (Far 7) - 0x19806 - True
+158181 - 0x1972F (Far 8) - 0x196F8 - True
 Door - 0x194B2 (Laser Entry Right) - 0x1972F
-158182 - 0x19797 (Near 1) - 0x0A8E0 - Shadows Follow
-158183 - 0x1979A (Near 2) - 0x19797 - Shadows Follow
-158184 - 0x197E0 (Near 3) - 0x1979A - Shadows Follow
-158185 - 0x197E8 (Near 4) - 0x197E0 - Shadows Follow
-158186 - 0x197E5 (Near 5) - 0x197E8 - Shadows Follow
+158182 - 0x19797 (Near 1) - 0x0A8E0 - True
+158183 - 0x1979A (Near 2) - 0x19797 - True
+158184 - 0x197E0 (Near 3) - 0x1979A - True
+158185 - 0x197E8 (Near 4) - 0x197E0 - True
+158186 - 0x197E5 (Near 5) - 0x197E8 - True
 Door - 0x19665 (Laser Entry Left) - 0x197E5
 
 Shadows Ledge (Shadows) - Shadows - 0x1855B - Quarry - 0x19865 & 0x0A2DF:
 158187 - 0x334DC (Door Timer Inside) - True - True
-158188 - 0x198B5 (Intro 1) - True - Shadows Avoid
-158189 - 0x198BD (Intro 2) - 0x198B5 - Shadows Avoid
-158190 - 0x198BF (Intro 3) - 0x198BD & 0x334DC & 0x19B24 - Shadows Avoid
+158188 - 0x198B5 (Intro 1) - True - True
+158189 - 0x198BD (Intro 2) - 0x198B5 - True
+158190 - 0x198BF (Intro 3) - 0x198BD & 0x334DC & 0x19B24 - True
 Door - 0x19865 (Quarry Barrier) - 0x198BF
 Door - 0x0A2DF (Quarry Barrier 2) - 0x198BF
-158191 - 0x19771 (Intro 4) - 0x198BF - Shadows Avoid
-158192 - 0x0A8DC (Intro 5) - 0x19771 - Shadows Avoid
+158191 - 0x19771 (Intro 4) - 0x198BF - True
+158192 - 0x0A8DC (Intro 5) - 0x19771 - True
 Door - 0x1855B (Ledge Barrier) - 0x0A8DC
 Door - 0x19ADE (Ledge Barrier 2) - 0x0A8DC
 
 Shadows Laser Room (Shadows):
-158703 - 0x19650 (Laser Panel) - True - Shadows Avoid & Shadows Follow
+158703 - 0x19650 (Laser Panel) - True - True
 Laser - 0x181B3 (Laser) - 0x19650
 
 Keep (Keep) - Main Island - True - Keep 2nd Maze - 0x01954 - Keep 2nd Pressure Plate - 0x01BEC:
-158193 - 0x00139 (Hedge Maze 1) - True - Environment
+158193 - 0x00139 (Hedge Maze 1) - True - True
 158197 - 0x0A3A8 (Reset Pressure Plates 1) - True - True
-158198 - 0x033EA (Pressure Plates 1) - 0x0A3A8 - Pressure Plates & Colored Squares & Triangles & Stars & Stars + Same Colored Symbol
+158198 - 0x033EA (Pressure Plates 1) - 0x0A3A8 - Colored Squares & Triangles & Stars & Stars + Same Colored Symbol
 Door - 0x01954 (Hedge Maze 1 Exit) - 0x00139
 Door - 0x01BEC (Pressure Plates 1 Exit) - 0x033EA
 
 Keep 2nd Maze (Keep) - Keep - 0x018CE - Keep 3rd Maze - 0x019D8:
 Door - 0x018CE (Hedge Maze 2 Shortcut) - 0x00139
-158194 - 0x019DC (Hedge Maze 2) - True - Environment
+158194 - 0x019DC (Hedge Maze 2) - True - True
 Door - 0x019D8 (Hedge Maze 2 Exit) - 0x019DC
 
 Keep 3rd Maze (Keep) - Keep - 0x019B5 - Keep 4th Maze - 0x019E6:
 Door - 0x019B5 (Hedge Maze 3 Shortcut) - 0x019DC
-158195 - 0x019E7 (Hedge Maze 3) - True - Environment & Sound
+158195 - 0x019E7 (Hedge Maze 3) - True - True
 Door - 0x019E6 (Hedge Maze 3 Exit) - 0x019E7
 
 Keep 4th Maze (Keep) - Keep - 0x0199A - Keep Tower - 0x01A0E:
 Door - 0x0199A (Hedge Maze 4 Shortcut) - 0x019E7
-158196 - 0x01A0F (Hedge Maze 4) - True - Environment
+158196 - 0x01A0F (Hedge Maze 4) - True - True
 Door - 0x01A0E (Hedge Maze 4 Exit) - 0x01A0F
 
 Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - True:
 158199 - 0x0A3B9 (Reset Pressure Plates 2) - True - True
-158200 - 0x01BE9 (Pressure Plates 2) - PP2 Weirdness - Pressure Plates & Stars & Stars + Same Colored Symbol & Squares & Black/White Squares & Shapers & Rotated Shapers
+158200 - 0x01BE9 (Pressure Plates 2) - PP2 Weirdness - Stars & Stars + Same Colored Symbol & Squares & Black/White Squares & Shapers & Rotated Shapers
 Door - 0x01BEA (Pressure Plates 2 Exit) - 0x01BE9
 
 Keep 3rd Pressure Plate (Keep) - Keep 4th Pressure Plate - 0x01CD5:
 158201 - 0x0A3BB (Reset Pressure Plates 3) - True - True
-158202 - 0x01CD3 (Pressure Plates 3) - 0x0A3BB - Pressure Plates & Black/White Squares & Triangles & Shapers & Rotated Shapers
+158202 - 0x01CD3 (Pressure Plates 3) - 0x0A3BB - Black/White Squares & Triangles & Shapers & Rotated Shapers
 Door - 0x01CD5 (Pressure Plates 3 Exit) - 0x01CD3
 
 Keep 4th Pressure Plate (Keep) - Shadows - 0x09E3D - Keep Tower - 0x01D40:
 158203 - 0x0A3AD (Reset Pressure Plates 4) - True - True
-158204 - 0x01D3F (Pressure Plates 4) - 0x0A3AD - Pressure Plates & Shapers & Triangles & Stars & Stars + Same Colored Symbol
+158204 - 0x01D3F (Pressure Plates 4) - 0x0A3AD - Shapers & Triangles & Stars & Stars + Same Colored Symbol
 Door - 0x01D40 (Pressure Plates 4 Exit) - 0x01D3F
 158604 - 0x17D27 (Discard) - True - Arrows
 158205 - 0x09E49 (Shadows Shortcut Panel) - True - True
 Door - 0x09E3D (Shadows Shortcut) - 0x09E49
 
 Shipwreck (Shipwreck) - Keep 3rd Pressure Plate - True:
-158654 - 0x00AFB (Vault) - True - Symmetry & Sound & Sound Dots & Colored Dots
+158654 - 0x00AFB (Vault) - True - Symmetry & Sound Dots & Colored Dots
 158655 - 0x03535 (Vault Box) - 0x00AFB - True
 158605 - 0x17D28 (Discard) - True - Arrows
 
 Keep Tower (Keep) - Keep - 0x04F8F:
 158206 - 0x0361B (Tower Shortcut Panel) - True - True
 Door - 0x04F8F (Tower Shortcut) - 0x0361B
-158704 - 0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - Environment & Sound
+158704 - 0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
 158705 - 0x03317 (Laser Panel Pressure Plates) - 0x01BE9 - Shapers & Rotated Shapers & Triangles & Stars & Stars + Same Colored Symbol & Colored Squares & Black/White Squares
 Laser - 0x014BB (Laser) - 0x0360E | 0x03317
 
@@ -365,19 +365,19 @@ Door - 0x0364E (Shortcut) - 0x03713
 158209 - 0x00C92 (Entry Right) - True - True
 Door - 0x0C128 (Entry Inner) - 0x00B10
 Door - 0x0C153 (Entry Outer) - 0x00C92
-158210 - 0x00290 (Outside 1) - 0x09D9B - Environment
-158211 - 0x00038 (Outside 2) - 0x09D9B & 0x00290 - Environment
-158212 - 0x00037 (Outside 3) - 0x09D9B & 0x00038 - Environment
+158210 - 0x00290 (Outside 1) - 0x09D9B - True
+158211 - 0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
+158212 - 0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
 Door - 0x03750 (Garden Entry) - 0x00037
 158706 - 0x17CA4 (Laser Panel) - 0x193A6 - True
 Laser - 0x17C65 (Laser) - 0x17CA4
 
 Inside Monastery (Monastery):
 158213 - 0x09D9B (Shutters Control) - True - Dots
-158214 - 0x193A7 (Inside 1) - 0x00037 - Environment
-158215 - 0x193AA (Inside 2) - 0x193A7 - Environment
-158216 - 0x193AB (Inside 3) - 0x193AA - Environment
-158217 - 0x193A6 (Inside 4) - 0x193AB - Environment
+158214 - 0x193A7 (Inside 1) - 0x00037 - True
+158215 - 0x193AA (Inside 2) - 0x193A7 - True
+158216 - 0x193AB (Inside 3) - 0x193AA - True
+158217 - 0x193A6 (Inside 4) - 0x193AB - True
 
 Monastery Garden (Monastery):
 
@@ -386,10 +386,10 @@ Town (Town) - Main Island - True - Boat - 0x0A054 - Town Maze Rooftop - 0x28AA2 
 158219 - 0x0A0C8 (Cargo Box Entry Panel) - True - Squares & Black/White Squares & Shapers & Triangles
 Door - 0x0A0C9 (Cargo Box Entry) - 0x0A0C8
 158707 - 0x09F98 (Desert Laser Redirect) - True - True
-158220 - 0x18590 (Transparent) - True - Symmetry & Environment
-158221 - 0x28AE3 (Vines) - 0x18590 - Shadows Follow & Environment
-158222 - 0x28938 (Apple Tree) - 0x28AE3 - Environment
-158223 - 0x079DF (Triple Exit) - 0x28938 - Shadows Avoid & Environment & Reflection
+158220 - 0x18590 (Transparent) - True - Symmetry
+158221 - 0x28AE3 (Vines) - 0x18590 - True
+158222 - 0x28938 (Apple Tree) - 0x28AE3 - True
+158223 - 0x079DF (Triple Exit) - 0x28938 - True
 158235 - 0x2899C (Wooden Roof Lower Row 1) - True - Triangles & Dots & Full Dots
 158236 - 0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Triangles & Dots & Full Dots
 158237 - 0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Triangles & Dots & Full Dots
@@ -398,9 +398,9 @@ Door - 0x0A0C9 (Cargo Box Entry) - 0x0A0C8
 Door - 0x034F5 (Wooden Roof Stairs) - 0x28AC1
 158225 - 0x28998 (Tinted Glass Door Panel) - True - Stars & Rotated Shapers & Stars + Same Colored Symbol
 Door - 0x28A61 (Tinted Glass Door) - 0x28A0D
-158226 - 0x28A0D (Church Entry Panel) - 0x28998 - Stars & RGB & Environment
+158226 - 0x28A0D (Church Entry Panel) - 0x28998 - Stars
 Door - 0x03BB0 (Church Entry) - 0x03C08
-158228 - 0x28A79 (Maze Stair Control) - True - Environment
+158228 - 0x28A79 (Maze Stair Control) - True - True
 Door - 0x28AA2 (Maze Stairs) - 0x28A79
 158241 - 0x17F5F (Windmill Entry Panel) - True - Dots
 Door - 0x1845B (Windmill Entry) - 0x17F5F
@@ -418,23 +418,23 @@ Town Red Rooftop (Town):
 158232 - 0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Shapers
 158233 - 0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Shapers
 158234 - 0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Shapers
-158224 - 0x28B39 (Tall Hexagonal) - 0x079DF - Reflection
+158224 - 0x28B39 (Tall Hexagonal) - 0x079DF - True
 
 Town Wooden Rooftop (Town):
 158240 - 0x28AD9 (Wooden Rooftop) - 0x28AC1 - Triangles & Dots & Full Dots & Eraser
 
 Town Church (Town):
-158227 - 0x28A69 (Church Lattice) - 0x03BB0 - Environment
+158227 - 0x28A69 (Church Lattice) - 0x03BB0 - True
 
 RGB House (Town) - RGB Room - 0x2897B:
-158242 - 0x034E4 (Sound Room Left) - True - Sound
-158243 - 0x034E3 (Sound Room Right) - True - Sound & Sound Dots
+158242 - 0x034E4 (Sound Room Left) - True - True
+158243 - 0x034E3 (Sound Room Right) - True - Sound Dots
 Door - 0x2897B (RGB House Stairs) - 0x034E4 & 0x034E3
 
 RGB Room (Town):
-158244 - 0x334D8 (RGB Control) - True - Rotated Shapers & RGB & Squares & Colored Squares & Triangles
-158245 - 0x03C0C (RGB Room Left) - 0x334D8 - RGB & Squares & Colored Squares & Black/White Squares & Eraser
-158246 - 0x03C08 (RGB Room Right) - 0x334D8 & 0x03C0C - RGB & Symmetry & Dots & Colored Dots & Triangles
+158244 - 0x334D8 (RGB Control) - True - Rotated Shapers & Squares & Colored Squares & Triangles
+158245 - 0x03C0C (RGB Room Left) - 0x334D8 - Squares & Colored Squares & Black/White Squares & Eraser
+158246 - 0x03C08 (RGB Room Right) - 0x334D8 & 0x03C0C - Symmetry & Dots & Colored Dots & Triangles
 
 Town Tower (Town Tower) - Town - True - Town Tower Top - 0x27798 & 0x27799 & 0x2779A & 0x2779C:
 Door - 0x27798 (First Door) - 0x28ACC
@@ -468,30 +468,30 @@ Door - 0x3CCDF (Exit Right) - 0x33AB2
 Jungle (Jungle) - Main Island - True - Outside Jungle River - 0x3873B - Boat - 0x17CDF:
 158251 - 0x17CDF (Shore Boat Spawn) - True - Boat
 158609 - 0x17F9B (Discard) - True - Triangles
-158252 - 0x002C4 (First Row 1) - True - Sound
-158253 - 0x00767 (First Row 2) - 0x002C4 - Sound
-158254 - 0x002C6 (First Row 3) - 0x00767 - Sound
-158255 - 0x0070E (Second Row 1) - 0x002C6 - Sound
-158256 - 0x0070F (Second Row 2) - 0x0070E - Sound
-158257 - 0x0087D (Second Row 3) - 0x0070F - Sound
-158258 - 0x002C7 (Second Row 4) - 0x0087D - Sound
+158252 - 0x002C4 (First Row 1) - True - True
+158253 - 0x00767 (First Row 2) - 0x002C4 - True
+158254 - 0x002C6 (First Row 3) - 0x00767 - True
+158255 - 0x0070E (Second Row 1) - 0x002C6 - True
+158256 - 0x0070F (Second Row 2) - 0x0070E - True
+158257 - 0x0087D (Second Row 3) - 0x0070F - True
+158258 - 0x002C7 (Second Row 4) - 0x0087D - True
 158259 - 0x17CAB (Popup Wall Control) - 0x002C7 - True
 Door - 0x1475B (Popup Wall) - 0x17CAB
-158260 - 0x0026D (Popup Wall 1) - 0x1475B - Sound & Sound Dots & Symmetry
-158261 - 0x0026E (Popup Wall 2) - 0x0026D - Sound & Sound Dots & Symmetry
-158262 - 0x0026F (Popup Wall 3) - 0x0026E - Sound & Sound Dots & Symmetry
-158263 - 0x00C3F (Popup Wall 4) - 0x0026F - Sound & Sound Dots & Symmetry
-158264 - 0x00C41 (Popup Wall 5) - 0x00C3F - Sound & Sound Dots & Symmetry
-158265 - 0x014B2 (Popup Wall 6) - 0x00C41 - Sound & Sound Dots & Symmetry
+158260 - 0x0026D (Popup Wall 1) - 0x1475B - Sound Dots & Symmetry
+158261 - 0x0026E (Popup Wall 2) - 0x0026D - Sound Dots & Symmetry
+158262 - 0x0026F (Popup Wall 3) - 0x0026E - Sound Dots & Symmetry
+158263 - 0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots & Symmetry
+158264 - 0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots & Symmetry
+158265 - 0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots & Symmetry
 158709 - 0x03616 (Laser Panel) - 0x014B2 - True
 Laser - 0x00274 (Laser) - 0x03616
 158266 - 0x337FA (Laser Shortcut Panel) - True - True
 Door - 0x3873B (Laser Shortcut) - 0x337FA
 
 Outside Jungle River (River) - Main Island - True - Monastery Garden - 0x0CF2A:
-158267 - 0x17CAA (Monastery Shortcut Panel) - True - Environment
+158267 - 0x17CAA (Monastery Shortcut Panel) - True - True
 Door - 0x0CF2A (Monastery Shortcut) - 0x17CAA
-158663 - 0x15ADD (Vault) - True - Environment & Black/White Squares & Dots
+158663 - 0x15ADD (Vault) - True - Black/White Squares & Dots
 158664 - 0x03702 (Vault Box) - 0x15ADD - True
 
 Outside Bunker (Bunker) - Main Island - True - Bunker - 0x0C2A4:
@@ -512,20 +512,20 @@ Bunker (Bunker) - Bunker Glass Room - 0x17C79:
 Door - 0x17C79 (Tinted Glass Door) - 0x0A099
 
 Bunker Glass Room (Bunker) - Bunker Ultraviolet Room - 0x0C2A3:
-158279 - 0x0A010 (Glass Room 1) - True - Squares & Colored Squares & RGB & Environment
-158280 - 0x0A01B (Glass Room 2) - 0x0A010 - Squares & Colored Squares & Black/White Squares & RGB & Environment
-158281 - 0x0A01F (Glass Room 3) - 0x0A01B - Squares & Colored Squares & Black/White Squares & RGB & Environment
+158279 - 0x0A010 (Glass Room 1) - True - Squares & Colored Squares
+158280 - 0x0A01B (Glass Room 2) - 0x0A010 - Squares & Colored Squares & Black/White Squares
+158281 - 0x0A01F (Glass Room 3) - 0x0A01B - Squares & Colored Squares & Black/White Squares
 Door - 0x0C2A3 (UV Room Entry) - 0x0A01F
 
 Bunker Ultraviolet Room (Bunker) - Bunker Elevator Section - 0x0A08D:
 158282 - 0x34BC5 (Drop-Down Door Open) - True - True
 158283 - 0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
-158284 - 0x17E63 (UV Room 1) - 0x34BC5 - Squares & Colored Squares & RGB & Environment
-158285 - 0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Squares & Colored Squares & Black/White Squares & RGB
+158284 - 0x17E63 (UV Room 1) - 0x34BC5 - Squares & Colored Squares
+158285 - 0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Squares & Colored Squares & Black/White Squares
 Door - 0x0A08D (Elevator Room Entry) - 0x17E67
 
 Bunker Elevator Section (Bunker) - Bunker Laser Platform - 0x0A079:
-158286 - 0x0A079 (Elevator Control) - True - Squares & Colored Squares & Black/White Squares & RGB
+158286 - 0x0A079 (Elevator Control) - True - Squares & Colored Squares & Black/White Squares
 
 Bunker Laser Platform (Bunker):
 158710 - 0x09DE0 (Laser Panel) - True - True
@@ -620,8 +620,8 @@ Swamp Blue Underwater (Swamp):
 158338 - 0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
 
 Swamp Maze (Swamp) - Swamp Laser Area - 0x17C0A & 0x17E07:
-158340 - 0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers & Environment
-158112 - 0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers & Environment
+158340 - 0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
+158112 - 0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
 
 Swamp Laser Area (Swamp) - Outside Swamp - 0x2D880:
 158711 - 0x03615 (Laser Panel) - True - True
@@ -895,8 +895,8 @@ Challenge (Challenge) - Tunnels - 0x0348A:
 158513 - 0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Squares & Black/White Squares & Colored Squares
 158514 - 0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
 158515 - 0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158516 - 0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry & Pillar
-158517 - 0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Squares & Black/White Squares & Symmetry & Pillar
+158516 - 0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
+158517 - 0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Squares & Black/White Squares & Symmetry
 158667 - 0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
 158518 - 0x039B4 (Tunnels Entry Panel) - True - Arrows
 Door - 0x0348A (Tunnels Entry) - 0x039B4


### PR DESCRIPTION
This cleanup PR tidies up the Witness logic files in three distinct (and independent) but related ways:

1. A small number of the "Door" and "Laser" lines in the logic files contain an extra ` - True` where symbol requirements would normally be, however door and laser panels don't use parsed symbol requirements. The first commit makes these lines consistent with all the other similar lines.

2. The Expert logic file contains "symbol" requirements relating to the island areas. [As per Discord](https://discord.com/channels/731205301247803413/980554001231786014/1045804550797402203) this is a legacy annotation and so the second commit removes all symbol references to the following requirements (replacing them with a `True` if they're otherwise the only remaining requirement)

* Environment
* Pillar
* Reflection
* RGB
* Shadows Avoid
* Shadows Follow
* Sound

3. The third commit fixes a typo where "Stars + Same Colored Symbol" was pluralized in exactly one place.